### PR TITLE
fix(biz): z-index issue

### DIFF
--- a/biz/FangyanziTable.tsx
+++ b/biz/FangyanziTable.tsx
@@ -299,8 +299,8 @@ const FangyanziTable = () => {
       <ui.FormControl as="fieldset">
         <ui.HStack>
           {/* https://github.com/chakra-ui/chakra-ui/issues/3173 */}
-          <ui.Box>{filterMenu}</ui.Box>
-          <ui.Box>{displayMenu}</ui.Box>
+          <ui.Box zIndex={20}>{filterMenu}</ui.Box>
+          <ui.Box zIndex={20}>{displayMenu}</ui.Box>
           <ui.Box>
             <ui.Input
               className="useHana"


### PR DESCRIPTION
选择列表与设定列表在触发时会被下方的字与释遮住
![屏幕截图(17)](https://user-images.githubusercontent.com/32487868/161936021-42f35007-abc3-4a7a-98e7-fb4fd7f859ea.png)
